### PR TITLE
Add mercenary unit forcepacks

### DIFF
--- a/src/data/force-packs-mechs.ts
+++ b/src/data/force-packs-mechs.ts
@@ -1,6 +1,7 @@
 export interface IForcePack {
     name: string;
     tech: string;
+	rules: string,
     groupLabel: string;
     members: string[];
 }
@@ -9,6 +10,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Command Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Daishi (Dire Wolf) Prime",
             "Ryoken (Stormcrow) Prime",
@@ -21,6 +23,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Striker Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Man O' War (Gargoyle) Prime",
             "Loki (Hellbringer) Prime",
@@ -30,9 +33,10 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         ],
     },
     {
-        name: "Clan Fire Star:",
+        name: "Clan Fire Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Masakari (Warhawk) Prime",
             "Nova Cat Prime",
@@ -45,6 +49,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Behemoth (Stone Rhino)",
             "Supernova",
@@ -57,6 +62,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Support Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Night Gyr Prime",
             "Hankyu (Arctic Cheetah) Prime",
@@ -69,6 +75,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Battle Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Turkina Prime",
             "Kingfisher Prime",
@@ -81,6 +88,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Striker Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Goshawk (Vapor Eagle)",
             "Hellhound (Conjurer)",
@@ -93,6 +101,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Ad Hoc Star",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Kodiak",
             "Pack Hunter",
@@ -105,6 +114,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Elementals",
         groupLabel: "Star",
         tech: "clan",
+		rules: "standard",
         members: [
             "Elemental Battle Armor [Laser] (sqd5)",
             "Elemental Battle Armor [Laser] (sqd5)",
@@ -117,6 +127,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Command Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Marauder MAD-3R",
             "Archer ARC-2R",
@@ -127,6 +138,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Battle Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Warhammer WHM-6R",
             "Rifleman RFL-3N",
@@ -137,6 +149,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Direct Fire Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Atlas AS7-D",
             "Marauder II MAD-4A",
@@ -147,6 +160,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Heavy Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Banshee BNC-3S",
             "Grasshopper GHR-5H",
@@ -157,6 +171,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Striker Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Blackjack BJ-1",
             "Jenner JR7-D ",
@@ -167,6 +182,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Fire Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Longbow LGB-0W",
             "Stalker STK-3F",
@@ -177,7 +193,8 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Heavy Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-        members: [
+        rules: "standard",
+		members: [
             "Nightstar NSR-9J",
             "Cataphract CTF-1X",
             "Axman AXM-1N",
@@ -187,6 +204,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Urban Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Victor VTR-9B",
             "Enforcer ENF-4R",
@@ -197,11 +215,113 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Support Lance",
         groupLabel: "Lance",
         tech: "is",
+		rules: "standard",
         members: [
             "Cyclops CP-10-Z",
             "Thug THG-11E",
             "Dragon DRG-1N",
             "Spider SDR-7M",
+        ],
+    },
+	{
+        name: "Wolf's Dragoons Assault Star",
+        groupLabel: "Star",
+        tech: "is+clan",
+		rules: "standard",
+        members: [
+            "Annihilator ANH-2A",
+            "Mad Cat (Timber Wolf) Prime",
+            "Rifleman RFL-3N",
+            "Archer ARC-2W",
+	 	   "Blackjack BJ-2",
+        ],
+    },{
+        name: "Eridani Light Horse Hunter Lance",
+        groupLabel: "Lance",
+        tech: "is",
+		rules: "standard",
+        members: [
+            "Thunderbolt TDR-5SE",
+            "Cyclops CP-11-A",
+            "Banshee BNC-3S",
+            "Sagittaire SGT-8R",
+        ],
+    },{
+        name: "Hansen's Roughriders Battle Lance",
+        groupLabel: "Lance",
+        tech: "is",
+		rules: "standard",
+        members: [
+            "Penetrator PTR-4D",
+            "Hatchetman HCT-6D",
+            "Enforcer ENF-5D",
+            "Atlas AS7-D",
+        ],
+    },{
+        name: "Northwind Highlanders Command Lance",
+        groupLabel: "Lance",
+        tech: "is",
+		rules: "standard",
+        members: [
+            "Grasshopper GHR-5J",
+            "Gunslinger GUN-1ERD",
+            "Highlander HGN-732",
+            "Warhammer WHM-7S",
+        ],
+    },{
+        name: "Kell Hounds Striker Lance",
+        groupLabel: "Lance",
+        tech: "is+clan",
+		rules: "advanced",
+        members: [
+            "Wolfhound WLF-6S",
+            "Griffin C",
+            "Crusader CRD-8R",
+            "Nightsky NGS-7S",
+        ],
+    },{
+        name: "Gray Death Legion Heavy Battle Lance",
+        groupLabel: "Lance",
+        tech: "is+clan",
+		rules: "standard",
+        members: [
+            "Regent Prime",
+            "Man O' War (Gargoyle) C",
+            "Catapult CPLT-K2K",
+            "Shadow Hawk SHD-7H",
+        ],
+    },{
+        name: "Snord's Irregulars Assault Lance",
+        groupLabel: "Lance",
+        tech: "is",
+		rules: "experimental",
+        members: [
+            "Spartan SPT-N2",
+            "Hybrid Rifleman RFL-3N (Sneede)",
+            "Guillotine GLT-3N",
+            "Highlander HGN-732",
+        ],
+    },{
+        name: "McCarron's Armored Cavalry Assault Lance",
+        groupLabel: "Lance",
+        tech: "is",
+		rules: "standard",
+        members: [
+            "Tian-Zong TNZ-N1",
+            "Black Knight BL-12-KNT",
+            "Awesome AWS-9Q",
+            "Starslayer STY-3Dr",
+        ],
+    },{
+        name: "Black Remnant Command Lance",
+        groupLabel: "Lance",
+        tech: "is+clan",
+		rules: "advanced",
+        members: [
+            "Cyclops CP-11-H",
+            "Flashman FLS-10E",
+            "Star Adder (Blood Asp) I",
+            "Dragon Fire DGR-3F",
         ],
     },
 ]

--- a/src/data/force-packs-mechs.ts
+++ b/src/data/force-packs-mechs.ts
@@ -1,7 +1,7 @@
 export interface IForcePack {
     name: string;
     tech: string;
-	rules: string,
+    rules: string,
     groupLabel: string;
     members: string[];
 }
@@ -10,7 +10,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Command Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Daishi (Dire Wolf) Prime",
             "Ryoken (Stormcrow) Prime",
@@ -23,7 +23,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Striker Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Man O' War (Gargoyle) Prime",
             "Loki (Hellbringer) Prime",
@@ -36,7 +36,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Fire Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Masakari (Warhawk) Prime",
             "Nova Cat Prime",
@@ -49,7 +49,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Behemoth (Stone Rhino)",
             "Supernova",
@@ -62,7 +62,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Support Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Night Gyr Prime",
             "Hankyu (Arctic Cheetah) Prime",
@@ -75,7 +75,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Battle Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Turkina Prime",
             "Kingfisher Prime",
@@ -88,7 +88,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Striker Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Goshawk (Vapor Eagle)",
             "Hellhound (Conjurer)",
@@ -101,7 +101,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Ad Hoc Star",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Kodiak",
             "Pack Hunter",
@@ -114,7 +114,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Elementals",
         groupLabel: "Star",
         tech: "clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Elemental Battle Armor [Laser] (sqd5)",
             "Elemental Battle Armor [Laser] (sqd5)",
@@ -127,7 +127,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Command Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Marauder MAD-3R",
             "Archer ARC-2R",
@@ -138,7 +138,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Warhammer WHM-6R",
             "Rifleman RFL-3N",
@@ -149,7 +149,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Direct Fire Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Atlas AS7-D",
             "Marauder II MAD-4A",
@@ -160,7 +160,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Heavy Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Banshee BNC-3S",
             "Grasshopper GHR-5H",
@@ -171,7 +171,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Striker Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Blackjack BJ-1",
             "Jenner JR7-D ",
@@ -182,7 +182,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Fire Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Longbow LGB-0W",
             "Stalker STK-3F",
@@ -194,7 +194,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         groupLabel: "Lance",
         tech: "is",
         rules: "standard",
-		members: [
+        members: [
             "Nightstar NSR-9J",
             "Cataphract CTF-1X",
             "Axman AXM-1N",
@@ -204,7 +204,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Urban Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Victor VTR-9B",
             "Enforcer ENF-4R",
@@ -215,7 +215,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Support Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Cyclops CP-10-Z",
             "Thug THG-11E",
@@ -223,23 +223,23 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
             "Spider SDR-7M",
         ],
     },
-	{
+    {
         name: "Wolf's Dragoons Assault Star",
         groupLabel: "Star",
         tech: "is+clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Annihilator ANH-2A",
             "Mad Cat (Timber Wolf) Prime",
             "Rifleman RFL-3N",
             "Archer ARC-2W",
-	 	   "Blackjack BJ-2",
+           "Blackjack BJ-2",
         ],
     },{
         name: "Eridani Light Horse Hunter Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Thunderbolt TDR-5SE",
             "Cyclops CP-11-A",
@@ -250,7 +250,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Hansen's Roughriders Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Penetrator PTR-4D",
             "Hatchetman HCT-6D",
@@ -261,7 +261,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Northwind Highlanders Command Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Grasshopper GHR-5J",
             "Gunslinger GUN-1ERD",
@@ -272,7 +272,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Kell Hounds Striker Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-		rules: "advanced",
+        rules: "advanced",
         members: [
             "Wolfhound WLF-6S",
             "Griffin C",
@@ -283,7 +283,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Gray Death Legion Heavy Battle Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Regent Prime",
             "Man O' War (Gargoyle) C",
@@ -294,7 +294,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Snord's Irregulars Assault Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "experimental",
+        rules: "experimental",
         members: [
             "Spartan SPT-N2",
             "Hybrid Rifleman RFL-3N (Sneede)",
@@ -305,7 +305,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "McCarron's Armored Cavalry Assault Lance",
         groupLabel: "Lance",
         tech: "is",
-		rules: "standard",
+        rules: "standard",
         members: [
             "Tian-Zong TNZ-N1",
             "Black Knight BL-12-KNT",
@@ -316,7 +316,7 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Black Remnant Command Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-		rules: "advanced",
+        rules: "advanced",
         members: [
             "Cyclops CP-11-H",
             "Flashman FLS-10E",

--- a/src/ui/pages/alpha-strike/roster/home.tsx
+++ b/src/ui/pages/alpha-strike/roster/home.tsx
@@ -49,12 +49,15 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
         newGroup.customName = pack.name;
 
         for( let member of pack.members ) {
-          let data: IASMULUnit[] = await getMULASSearchResults(
+          let data: IASMULUnit[] = await getMULASSearchResults  (
             member,
-            "intro+standard",
-            pack.tech === "clan" ? "clan" : "inner sphere",
+              // not all lance packs are standard rules any more
+            pack.rules === "experimental" ? "intro+standard+advanced+experimental" :
+               pack.rules === "advanced" ? "intro+standard+advanced" : "intro+standard",
+            // some lance packs are mixed (is/clan) if not 'is' then 'clan' or 'is+clan'
+            pack.tech === "is" ? "inner sphere" : pack.tech,
             "", // Role
-            0, // clan invasion
+            0, // FIXME? clan invasion
             0, // Type Filter
             [], //Faction Filter
             !navigator.onLine,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,18 @@ export async function getMULASSearchResults(
         rulesNumbersURI.push( "&Rules=55" );
         rulesNumbersURI.push( "&Rules=4" );
     }
+    if( mechRules.toLowerCase() === "intro+standard+advanced" ) {
+        rulesNumbersURI.push( "&Rules=55" );
+        rulesNumbersURI.push( "&Rules=4" );
+        rulesNumbersURI.push( "&Rules=5" );
+        rulesNumbersURI.push( "&Rules=6" );
+    }
+    if( mechRules.toLowerCase() === "intro+standard+advanced+experimental" ) {
+        rulesNumbersURI.push( "&Rules=55" );
+        rulesNumbersURI.push( "&Rules=4" );
+        rulesNumbersURI.push( "&Rules=5" );
+        rulesNumbersURI.push( "&Rules=6" );
+    }
     if( mechRules.toLowerCase() === "experimental" ) {
         rulesNumbersURI.push( "&Rules=6" );
     }
@@ -70,6 +82,9 @@ export async function getMULASSearchResults(
     }
 
     let techFilterURI: string[] = [];
+    // we can get passed 'is+clan' here from home.tsx if we're searching for mechs
+    // in a mixed-tech lance (e.g. GDL, WD, KH) - we just skip any filtering
+    // at this point.
     if( techFilter.toLowerCase() === "inner sphere" ) {
         techFilterURI.push( "&Technologies=1" );
     }


### PR DESCRIPTION
research work and data entry - Shadoblade
putting lid back on can of worms (at least for now) - FleetfootMike

Original force pack code assumes all packs are either purely IS or Clan tech, and no more than 'standard' rules level. This... is really not so any more. 