### PR TITLE
comstar etc forcepacks

### DIFF
--- a/src/data/force-packs-mechs.ts
+++ b/src/data/force-packs-mechs.ts
@@ -1,7 +1,6 @@
 export interface IForcePack {
     name: string;
     tech: string;
-    rules: string,
     groupLabel: string;
     members: string[];
 }
@@ -10,7 +9,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Command Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Daishi (Dire Wolf) Prime",
             "Ryoken (Stormcrow) Prime",
@@ -23,7 +21,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Striker Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Man O' War (Gargoyle) Prime",
             "Loki (Hellbringer) Prime",
@@ -36,7 +33,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Fire Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Masakari (Warhawk) Prime",
             "Nova Cat Prime",
@@ -49,7 +45,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Behemoth (Stone Rhino)",
             "Supernova",
@@ -62,7 +57,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Support Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Night Gyr Prime",
             "Hankyu (Arctic Cheetah) Prime",
@@ -75,7 +69,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Heavy Battle Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Turkina Prime",
             "Kingfisher Prime",
@@ -88,7 +81,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Striker Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Goshawk (Vapor Eagle)",
             "Hellhound (Conjurer)",
@@ -101,7 +93,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Ad Hoc Star",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Kodiak",
             "Pack Hunter",
@@ -114,7 +105,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Clan Elementals",
         groupLabel: "Star",
         tech: "clan",
-        rules: "standard",
         members: [
             "Elemental Battle Armor [Laser] (sqd5)",
             "Elemental Battle Armor [Laser] (sqd5)",
@@ -127,7 +117,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Command Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Marauder MAD-3R",
             "Archer ARC-2R",
@@ -138,7 +127,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Warhammer WHM-6R",
             "Rifleman RFL-3N",
@@ -149,7 +137,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Direct Fire Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Atlas AS7-D",
             "Marauder II MAD-4A",
@@ -160,7 +147,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Heavy Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Banshee BNC-3S",
             "Grasshopper GHR-5H",
@@ -171,7 +157,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Striker Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Blackjack BJ-1",
             "Jenner JR7-D ",
@@ -182,7 +167,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Fire Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Longbow LGB-0W",
             "Stalker STK-3F",
@@ -193,7 +177,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Heavy Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Nightstar NSR-9J",
             "Cataphract CTF-1X",
@@ -204,7 +187,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Urban Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Victor VTR-9B",
             "Enforcer ENF-4R",
@@ -215,7 +197,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Inner Sphere Support Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Cyclops CP-10-Z",
             "Thug THG-11E",
@@ -227,7 +208,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Wolf's Dragoons Assault Star",
         groupLabel: "Star",
         tech: "is+clan",
-        rules: "standard",
         members: [
             "Annihilator ANH-2A",
             "Mad Cat (Timber Wolf) Prime",
@@ -239,7 +219,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Eridani Light Horse Hunter Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Thunderbolt TDR-5SE",
             "Cyclops CP-11-A",
@@ -250,7 +229,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Hansen's Roughriders Battle Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Penetrator PTR-4D",
             "Hatchetman HCT-6D",
@@ -261,7 +239,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Northwind Highlanders Command Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Grasshopper GHR-5J",
             "Gunslinger GUN-1ERD",
@@ -272,7 +249,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Kell Hounds Striker Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-        rules: "advanced",
         members: [
             "Wolfhound WLF-6S",
             "Griffin C",
@@ -283,7 +259,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Gray Death Legion Heavy Battle Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-        rules: "standard",
         members: [
             "Regent Prime",
             "Man O' War (Gargoyle) C",
@@ -294,7 +269,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Snord's Irregulars Assault Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "experimental",
         members: [
             "Spartan SPT-N2",
             "Hybrid Rifleman RFL-3N (Sneede)",
@@ -305,7 +279,6 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "McCarron's Armored Cavalry Assault Lance",
         groupLabel: "Lance",
         tech: "is",
-        rules: "standard",
         members: [
             "Tian-Zong TNZ-N1",
             "Black Knight BL-12-KNT",
@@ -316,12 +289,68 @@ export const CONST_FORCE_PACKS: IForcePack[] = [
         name: "Black Remnant Command Lance",
         groupLabel: "Lance",
         tech: "is+clan",
-        rules: "advanced",
         members: [
             "Cyclops CP-11-H",
             "Flashman FLS-10E",
             "Star Adder (Blood Asp) I",
             "Dragon Fire DGR-3F",
+        ],
+    },{
+        name: "BattleTech: Proliferation Cycle Pack",
+        groupLabel: "Lance",
+        tech: "is+clan",
+        members: [
+            "Battleaxe BKX-7K",
+            "Ymir BWP-2B",
+            "Coyotl D",
+            "Firebee FRB-1E (WAM-B)",
+            "Gladiator GLD-1R",
+            "Icarus II ICR-1S",
+            "Mackie MSK-5S",
+         ],
+    },{
+        name: "BattleTech: UrbanMech Lance",
+        groupLabel: "Lance",
+        tech: "is",
+        members: [
+            "UrbanMech UM-R60L",
+            "UrbanMech UM-R60",
+            "UrbanMech UM-R27",
+            "UrbanMech UM-R68",
+        ],
+    },{
+        name: "Legendary MechWarriors Pack",
+        groupLabel: "Lance",
+        tech: "is+clan",
+        members: [
+            "Daishi (Dire Wolf) \"Widowmaker\"",
+            "Archer ARC-2R",
+            "Marauder MAD-3R",
+            "Mad Cat (Timber Wolf) (Pryde)",
+        ],
+    },{
+        name: "ComStar Command Level II",
+        groupLabel: "Level II",
+        tech: "is",
+        members: [
+            "Black Knight BL-6-KNT",
+            "Exterminator EXT-4A",
+            "Highlander HGN-732",
+            "King Crab KGC-000",
+            "Mercury MCY-98",
+            "Sentinel STN-3K",
+        ],
+    },{
+        name: "ComStar Battle Level II",
+        groupLabel: "Level II",
+        tech: "is",
+        members: [
+            "Crab CRB-20",
+            "Crockett CRK-5003-0",
+            "Flashman FLS-7K",
+            "Guillotine GLT-3N",
+            "Lancelot LNC25-01",
+            "Mongoose MON-66",
         ],
     },
 ]

--- a/src/ui/pages/alpha-strike/roster/home.tsx
+++ b/src/ui/pages/alpha-strike/roster/home.tsx
@@ -49,13 +49,11 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
         newGroup.customName = pack.name;
 
         for( let member of pack.members ) {
+          // we are searching for an explicit name match, nothing more.
           let data: IASMULUnit[] = await getMULASSearchResults  (
             member,
-              // not all lance packs are standard rules any more
-            pack.rules === "experimental" ? "intro+standard+advanced+experimental" :
-               pack.rules === "advanced" ? "intro+standard+advanced" : "intro+standard",
-            // some lance packs are mixed (is/clan) if not 'is' then 'clan' or 'is+clan'
-            pack.tech === "is" ? "inner sphere" : pack.tech,
+            "", // Rules
+            "", // Tech
             "", // Role
             0, // FIXME? clan invasion
             0, // Type Filter
@@ -112,165 +110,22 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
           )
 
           // console.log( "data", data)
-
+          // looking for an exact name match only
           let foundAUnit = false;
-
-          if( data.length === 1 ) {
-            let newUnit = new AlphaStrikeUnit();
-            newUnit.importMUL( data[0] );
-            if( pack.tech === "clan" ) newUnit.setSkill(3);
-            newGroup.members.push(
-              newUnit
-            )
-            foundAUnit = true;
-          } else {
-            // look for Intro first...
-            for( let item of data ) {
-              if( item.Rules.toLowerCase().trim() === "introductory" ) {
-                if( item.Name && item.Name.toLowerCase().indexOf(" prime") > -1 ) {
-                  // console.log("Adding intro rules unit via prime in name", item.Name, item.RS)
-                  let newUnit = new AlphaStrikeUnit();
-                  newUnit.importMUL( item );
-
-                  if( pack.tech === "clan" ) newUnit.setSkill(3);
-
-                  newGroup.members.push(
-                    newUnit
-                  )
-
-                  foundAUnit = true;
-                  break;
-                }
-                if( item.Name && item.Name.toLowerCase().indexOf(" (standard)") > -1 ) {
-                  // console.log("Adding intro rules unit via prime in name", item.Name, item.RS)
-                  let newUnit = new AlphaStrikeUnit();
-                  newUnit.importMUL( item );
-
-                  if( pack.tech === "clan" ) newUnit.setSkill(3);
-
-                  newGroup.members.push(
-                    newUnit
-                  )
-
-                  foundAUnit = true;
-                  break;
-                }
-                if( item.RS && item.RS.toLowerCase().indexOf("rs3039") > -1 ) {
-                  // console.log("Adding intro rules unit via rs3039", item.Name, item.RS)
-                  let newUnit = new AlphaStrikeUnit();
-                  newUnit.importMUL( item );
-                  if( pack.tech === "clan" ) newUnit.setSkill(3);
-                  newGroup.members.push(
-                    newUnit
-                  )
-                  foundAUnit = true;
-                  break;
-                }
-
-                if( item.RS && item.RS.toLowerCase().indexOf("rs3050") > -1 ) {
-
-                  // console.log("Adding intro rules unit via rs3050", item.Name, item.RS)
-                  let newUnit = new AlphaStrikeUnit();
-                  newUnit.importMUL( item );
-                  if( pack.tech === "clan" ) newUnit.setSkill(3);
-                  newGroup.members.push(
-                    newUnit
-                  )
-                  foundAUnit = true;
-                  break;
-                }
-              }
-
-            }
-
-            if(!foundAUnit) {
-              // console.log("data", data)
-              for( let item of data ) {
-                if( item.Rules.toLowerCase().trim() === "standard" ) {
-                  if( item.Name && item.Name.toLowerCase().indexOf(" prime") > -1 ) {
-                    // console.log("Adding unit via prime in name", item.Name, item.RS)
-                    let newUnit = new AlphaStrikeUnit();
-                    newUnit.importMUL( item );
-                    if( pack.tech === "clan" ) newUnit.setSkill(3);
-                    newGroup.members.push(
-                      newUnit
-                    )
-                    foundAUnit = true;
-                    break;
-                  }
-                  if( item.Name && item.Name.toLowerCase().indexOf(" (standard)") > -1 ) {
-                    // console.log("Adding intro rules unit via prime in name", item.Name, item.RS)
-                    let newUnit = new AlphaStrikeUnit();
-                    newUnit.importMUL( item );
-
-                    if( pack.tech === "clan" ) newUnit.setSkill(3);
-
-                    newGroup.members.push(
-                      newUnit
-                    )
-
-                    foundAUnit = true;
-                    break;
-                  }
-                  if( item.RS && item.RS.toLowerCase().indexOf("rs3039") > -1 ) {
-                    // console.log("Adding unit via rs3039", item.Name, item.RS)
-                    let newUnit = new AlphaStrikeUnit();
-                    newUnit.importMUL( item );
-                    if( pack.tech === "clan" ) newUnit.setSkill(3);
-                    newGroup.members.push(
-                      newUnit
-                    )
-                    foundAUnit = true;
-                    break;
-                  }
-
-                  if( item.RS && item.RS.toLowerCase().indexOf("rs3050") > -1 ) {
-
-                    // console.log("Adding unit via rs3050", item, item.Name, item.RS)
-                    let newUnit = new AlphaStrikeUnit();
-                    newUnit.importMUL( item );
-                    if( pack.tech === "clan" ) newUnit.setSkill(3);
-                    newGroup.members.push(
-                      newUnit
-                    )
-                    foundAUnit = true;
-                    break;
-                  }
-                  if( item.RS && item.RS.toLowerCase().indexOf("rg") === 0 ) {
-
-                    // console.log("Adding unit via rg*", item, item.Name, item.RS)
-                    let newUnit = new AlphaStrikeUnit();
-                    newUnit.importMUL( data[0]  );
-                    if( pack.tech === "clan" ) newUnit.setSkill(3);
-                    newGroup.members.push(
-                      newUnit
-                    )
-                    foundAUnit = true;
-                    break;
-                  }
-                }
-
-              }
-            }
-          }
-
-
-          if(!foundAUnit) {
-            if( data[0] ) {
-              // try to add the first found...
+          for( let item of data ) {
+            if( item.Name.toLowerCase() === member.toLowerCase() ) {
               let newUnit = new AlphaStrikeUnit();
-              newUnit.importMUL( data[0]  );
+              newUnit.importMUL( item );
               if( pack.tech === "clan" ) newUnit.setSkill(3);
-              newGroup.members.push(
-                newUnit
-              )
-            } else {
-              console.log("No match found for '" + member +"' data", data);
+              newGroup.members.push(newUnit);
+              foundAUnit = true;
+              break;
             }
           }
-
+          if ( !foundAUnit ) {
+            console.log("No match found for '" + member +"' data", data);
+          }
         }
-
 
         if( newGroup.members.length > 0 ) {
           newGroup.setAvailableFormationBonuses(formationBonuses.filter(x=>x.IsValid(newGroup)))
@@ -280,10 +135,7 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
             updated: true,
           })
         }
-
       }
-
-
     }
 
     removeFavoriteConfirm = ( asFavGroupIndex: number ): void => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,6 @@ export async function getMULASSearchResults(
         rulesNumbersURI.push( "&Rules=55" );
         rulesNumbersURI.push( "&Rules=4" );
         rulesNumbersURI.push( "&Rules=5" );
-        rulesNumbersURI.push( "&Rules=6" );
     }
     if( mechRules.toLowerCase() === "intro+standard+advanced+experimental" ) {
         rulesNumbersURI.push( "&Rules=55" );


### PR DESCRIPTION
Add (data entry from Shadoblade)
- Proliferation Cycle
- UrbanMechs
- Legendary MechWarriors I
- ComStar Battle Level II
- ComStar Command Level II

Simplify and fix the MUL search code to do a (case insensitive) exact name match (and get rid of uneccessary matching logic).
Remove rules from `IForcePack`