### PR TITLE
Grid view options to in-play view

### DIFF
--- a/src/ui/classes/app_settings.ts
+++ b/src/ui/classes/app_settings.ts
@@ -15,7 +15,7 @@ export class AppSettings {
 
     alphasStrikeCachedSearchResults: IASMULUnit[] = [];
     alphaStrikeSearchTerm: string = "";
-    alphaStrikeInPlayCardMode: boolean = false;
+    alphaStrikeInPlayColumns: number = 2;
     alphaStrikeSearchRules: string = "";
     alphaStrikeSearchTech: string = "";
     alphaStrikeSearchRole: string = "";
@@ -66,8 +66,8 @@ export class AppSettings {
                 this.alphaStrikeSearchTerm = io.alphaStrikeSearchTerm;
             }
 
-            if ( typeof( io.alphaStrikeInPlayCardMode ) !== "undefined" ) {
-                this.alphaStrikeInPlayCardMode = io.alphaStrikeInPlayCardMode;
+            if ( typeof( io.alphaStrikeInPlayColumns ) !== "undefined" ) {
+                this.alphaStrikeInPlayColumns = io.alphaStrikeInPlayColumns;
             }
 
             if ( typeof( io.equipmentEditorFile ) !== "undefined" ) {
@@ -113,7 +113,7 @@ export class AppSettings {
             installEquipCategory: this.installEquipCategory,
             alphasStrikeCachedSearchResults: this.alphasStrikeCachedSearchResults,
             alphaStrikeSearchTerm: this.alphaStrikeSearchTerm,
-            alphaStrikeInPlayCardMode: this.alphaStrikeInPlayCardMode,
+            alphaStrikeInPlayColumns: this.alphaStrikeInPlayColumns,
             equipmentEditorFile: this.equipmentEditorFile,
             alphaStrikeSearchRules: this.alphaStrikeSearchRules,
             alphaStrikeSearchEra: this.alphaStrikeSearchEra,
@@ -145,7 +145,7 @@ export interface IAppSettingsExport {
     alphaStrikeSearchRole: string;
     alphaStrikeSearchEra: number;
     alphaStrikeSearchType: number;
-    alphaStrikeInPlayCardMode: boolean;
+    alphaStrikeInPlayColumns: number;
     alphaStrikeMeasurementsInHexes: boolean;
     alphaStrikeSearchFactions: Array<number>;
     hideMPIntro: boolean;

--- a/src/ui/pages/alpha-strike/roster/in-play.scss
+++ b/src/ui/pages/alpha-strike/roster/in-play.scss
@@ -1,0 +1,25 @@
+.flex-grid {
+    flex-flow: row wrap;
+    display: flex;
+    .unit-card {
+        padding: 5px;
+        text-align: center;
+    }
+    &.flex-1 .unit-card {
+        flex-basis: 100%;
+        padding: 10px 0;
+    }
+    &.flex-2 .unit-card {
+        flex-basis: 50%;
+        padding: 10px;
+    }
+    &.flex-3 .unit-card {
+        flex-basis: 33.333%;
+    }
+    &.flex-4 .unit-card {
+        flex-basis: 25%;
+    }
+    &.flex-5 .unit-card {
+        flex-basis: 20%;
+    }
+}

--- a/src/ui/pages/alpha-strike/roster/in-play.tsx
+++ b/src/ui/pages/alpha-strike/roster/in-play.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FaArrowCircleLeft, FaList, FaTh } from "react-icons/fa";
+import { FaArrowCircleLeft, FaColumns } from "react-icons/fa";
 import { FiRefreshCcw } from "react-icons/fi";
 import { Link } from 'react-router-dom';
 import AlphaStrikeGroup from '../../../../classes/alpha-strike-group';
@@ -39,7 +39,12 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
 
       let appSettings = this.props.appGlobals.appSettings;
 
-      appSettings.alphaStrikeInPlayCardMode = !appSettings.alphaStrikeInPlayCardMode;
+      if (appSettings.alphaStrikeInPlayColumns < 5) {
+        appSettings.alphaStrikeInPlayColumns++;
+      } else {
+        appSettings.alphaStrikeInPlayColumns = 1;
+      }
+
       this.props.appGlobals.saveAppSettings( appSettings );
 
     }
@@ -149,12 +154,7 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
           <ul className="main-menu">
                 <li><Link title="Click here to leave Play Mode (don't worry, you won't lose your current mech statuses)" className="current" to={`${process.env.PUBLIC_URL}/alpha-strike-roster`}><FaArrowCircleLeft /></Link></li>
 
-                {this.props.appGlobals.appSettings.alphaStrikeInPlayCardMode ? (
-                  <li title="Switch a large list mode"><span className="current" onClick={this.toggleCardMode}><FaList /></span></li>
-                ) : (
-                  <li title="Switch to showing 2+ cards per row"><span className="current" onClick={this.toggleCardMode}><FaTh /></span></li>
-
-                )}
+                <li title="Switch to showing 2+ cards per row"><span className="current" onClick={this.toggleCardMode}><FaColumns /> {this.props.appGlobals.appSettings.alphaStrikeInPlayColumns}</span></li>
 
                 <li>
                   <AlphaStrikeToggleRulerHexes
@@ -197,10 +197,10 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
                   {group.getName(groupIndex + 1)}
                 </h2>
                 <div className="section-content">
-                  <div className="row">
+                  <div className={"flex-grid flex-" + this.props.appGlobals.appSettings.alphaStrikeInPlayColumns}>
                   {group.formationBonus!.Name!=="None"?(
                     <>
-                    <div className={this.props.appGlobals.appSettings.alphaStrikeInPlayCardMode ? "col-md-12" : "col-md-12"}>
+                    <div>
                       <p><strong>Bonus</strong>:&nbsp;
                       <em>{group.formationBonus!.Name}</em> - {group.formationBonus!.BonusDescription}</p>
                     </div>
@@ -213,7 +213,7 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
                     // let newInstance = new AlphaStrikeUnit( unit.export() );
                     return (
                     <React.Fragment key={unitIndex}>
-                      <div className={this.props.appGlobals.appSettings.alphaStrikeInPlayCardMode ? "col-md-6 col-lg-6 col-xl-3 col-xxl-2" : "col-md-12"}>
+                      <div className="unit-card">
                         <AlphaStrikeUnitSVG
                           asUnit={unit}
                           inPlay={true}


### PR DESCRIPTION
This is a small change that updates the in-play view to allow users to click through 1-5 column layouts. This should be helpful to allow folks to set their view to a usable size on various devices.