### PR TITLE
Ability to distinguish current turn damage/heat from those already in effect.

### DIFF
--- a/src/classes/alpha-strike-unit.ts
+++ b/src/classes/alpha-strike-unit.ts
@@ -105,6 +105,17 @@ export interface IAlphaStrikeUnitExport {
     vehicleMotive11?: boolean[];
     vehicleMotive12?: boolean;
 
+    roundArmor?: boolean[];
+    roundStructure?: boolean[];
+    roundEngineHits?: boolean[];
+    roundFireControlHits?: boolean[];
+    roundMpControlHits?: boolean[];
+    roundWeaponHits?: boolean[];
+    roundVehicleMotive910?: boolean[];
+    roundVehicleMotive11?: boolean[];
+    roundVehicleMotive12?: boolean;
+    roundHeat?: number;
+
     tmm: number;
     // Additional Fields we use internally
     classification: string;
@@ -211,7 +222,6 @@ export class AlphaStrikeUnit {
 
     public basePoints: number = 0;
     public currentPoints: number = 0;
-    public currentHeat: number = 0;
 
     public currentDamage: IAlphaStrikeDamage = {
         short: 0,
@@ -224,6 +234,7 @@ export class AlphaStrikeUnit {
         extremeMinimal: false,
     };
 
+    public currentHeat: number = 0;
     public currentArmor: boolean[] = [];
     public currentStructure: boolean[] = [];
     public engineHits: boolean[] = [];
@@ -234,6 +245,17 @@ export class AlphaStrikeUnit {
     public vehicleMotive910: boolean[] = [];
     public vehicleMotive11: boolean[] = [];
     public vehicleMotive12: boolean = false;
+
+    public roundHeat: number = 0;
+    public roundArmor: boolean[] = [];
+    public roundStructure: boolean[] = [];
+    public roundEngineHits: boolean[] = [];
+    public roundFireControlHits: boolean[] = [];
+    public roundMpControlHits: boolean[] = [];
+    public roundWeaponHits: boolean[] = [];
+    public roundVehicleMotive910: boolean[] = [];
+    public roundVehicleMotive11: boolean[] = [];
+    public roundVehicleMotive12: boolean = false;
 
     private _pilot: Pilot = new Pilot( {
         name: "",
@@ -495,6 +517,46 @@ export class AlphaStrikeUnit {
         if( incomingMechData.weaponHits )
             this.weaponHits = incomingMechData.weaponHits;
 
+        if( incomingMechData.roundArmor ) {
+            this.roundArmor = incomingMechData.roundArmor;
+        }
+
+        if( incomingMechData.roundStructure ) {
+            this.roundStructure = incomingMechData.roundStructure;
+        }
+
+        if( incomingMechData.roundEngineHits ) {
+            this.roundEngineHits = incomingMechData.roundEngineHits;
+        }
+
+        if( incomingMechData.roundFireControlHits ) {
+            this.roundFireControlHits = incomingMechData.roundFireControlHits;
+        }
+
+        if( incomingMechData.roundMpControlHits ) {
+            this.roundMpControlHits = incomingMechData.roundMpControlHits;
+        }
+
+        if( incomingMechData.roundWeaponHits ) {
+            this.roundWeaponHits = incomingMechData.roundWeaponHits;
+        }
+
+        if( incomingMechData.roundVehicleMotive910 ) {
+            this.roundVehicleMotive910 = incomingMechData.roundVehicleMotive910;
+        }
+
+        if( incomingMechData.roundVehicleMotive11 ) {
+            this.roundVehicleMotive11 = incomingMechData.roundVehicleMotive11;
+        }
+
+        if( incomingMechData.roundVehicleMotive12 ) {
+            this.roundVehicleMotive12 = incomingMechData.roundVehicleMotive12;
+        }
+
+        if( incomingMechData.roundHeat ) {
+            this.roundHeat = incomingMechData.roundHeat;
+        }
+
             if( incomingMechData.customName )
             this.customName = incomingMechData.customName;
 
@@ -714,6 +776,67 @@ export class AlphaStrikeUnit {
         return false;
     }
 
+    public hasRoundStaged(): boolean {
+
+        if (this.roundHeat !== this.currentHeat) {
+            return true;
+        }
+
+        for( let point of this.roundArmor ) {
+            if (point) {
+                return true;
+            }
+        }
+        for( let point of this.roundStructure ) {
+            if (point) {
+                return true;
+            }
+        }
+        for( let point of this.roundEngineHits ) {
+            if (point) {
+                return true;
+            }
+        }
+        for( let point of this.roundFireControlHits ) {
+            if (point) {
+                return true;
+            }
+        }
+        for( let point of this.roundMpControlHits ) {
+            if (point) {
+                return true;
+            }
+        }
+        for( let point of this.roundWeaponHits ) {
+            if (point) {
+                return true;
+            }
+        }
+
+        if(
+            ( this.type && this.type.trim().toLowerCase() === "sv" )
+                ||
+            ( this.type && this.type.trim().toLowerCase() === "cv" )
+        ) {
+
+            for( let mpHitsCount = 0; mpHitsCount < this.roundVehicleMotive910.length; mpHitsCount++) {
+                if( this.roundVehicleMotive910[ mpHitsCount ] ) {
+                    return true;
+                }
+            }
+            for( let mpHitsCount = 0; mpHitsCount < this.vehicleMotive11.length; mpHitsCount++) {
+                if( this.roundVehicleMotive11[ mpHitsCount ] ) {
+                    return true;
+                }
+            }
+
+            if( this.roundVehicleMotive12 ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     public getEngineHits(): number {
         let rv = 0;
@@ -795,10 +918,19 @@ export class AlphaStrikeUnit {
         this.fireControlHits = [];
         this.weaponHits = [];
         this.mpControlHits = [];
-        this.engineHits = [];
         this.vehicleMotive910 = [];
         this.vehicleMotive11 = [];
         this.vehicleMotive12 = false;
+        this.roundArmor = [];
+        this.roundStructure = [];
+        this.roundHeat = 0;
+        this.roundEngineHits = [];
+        this.roundFireControlHits = [];
+        this.roundWeaponHits = [];
+        this.roundMpControlHits = [];
+        this.roundVehicleMotive910 = [];
+        this.roundVehicleMotive11 = [];
+        this.roundVehicleMotive12 = false;
         this.calcCurrentValues();
     }
 
@@ -907,44 +1039,60 @@ export class AlphaStrikeUnit {
 
         if( typeof( this.currentArmor ) === "undefined" || this.currentArmor.length === 0 ) {
             this.currentArmor = [];
-            for( let armorCount = 0; armorCount < this.armor; armorCount++)
+            this.roundArmor = [];
+            for( let armorCount = 0; armorCount < this.armor; armorCount++) {
                 this.currentArmor.push( false );
+                this.roundArmor.push( false );
+            }
         }
 
         if( typeof( this.currentStructure ) === "undefined" || this.currentStructure.length === 0 ) {
             this.currentStructure = [];
-            for( let structureCount = 0; structureCount < this.structure; structureCount++)
+            this.roundStructure = [];
+            for( let structureCount = 0; structureCount < this.structure; structureCount++) {
                 this.currentStructure.push( false );
+                this.roundStructure.push( false );
+            }
         }
 
         if( typeof( this.engineHits ) === "undefined"  || this.engineHits.length === 0  ) {
             this.engineHits = [];
-            for( let engineHitsCount = 0; engineHitsCount < 2; engineHitsCount++)
+            this.roundEngineHits = [];
+            for( let engineHitsCount = 0; engineHitsCount < 2; engineHitsCount++) {
                 this.engineHits.push( false );
+                this.roundEngineHits.push( false );
+            }
         }
 
         if( typeof( this.fireControlHits ) === "undefined"  || this.fireControlHits.length === 0  ) {
             this.fireControlHits = [];
-            for( let fcHitsCount = 0; fcHitsCount < 4; fcHitsCount++)
+            this.roundFireControlHits = [];
+            for( let fcHitsCount = 0; fcHitsCount < 4; fcHitsCount++) {
                 this.fireControlHits.push( false );
+                this.roundFireControlHits.push( false );
+            }
         }
 
         if( typeof(this.vehicleMotive910) === "undefined" || this.vehicleMotive910.length === 0 ) {
-            this.vehicleMotive11 = [];
+            this.vehicleMotive910 = [];
+            this.roundVehicleMotive910 = [];
             for(let hitCount = 0; hitCount < 2; hitCount++) {
                 this.vehicleMotive910.push( false );
+                this.roundVehicleMotive910.push( false );
             }
         }
         if( typeof(this.vehicleMotive11) === "undefined" || this.vehicleMotive11.length === 0 ) {
             this.vehicleMotive11 = [];
+            this.roundVehicleMotive11 = [];
             for(let hitCount = 0; hitCount < 2; hitCount++) {
                 this.vehicleMotive11.push( false );
+                this.roundVehicleMotive11.push( false );
             }
         }
 
-
         if( typeof( this.mpControlHits ) === "undefined"  || this.mpControlHits.length === 0  ) {
             this.mpControlHits = [];
+            this.roundMpControlHits = [];
             let numberOfHits = 4;
             if(
                 ( this.type && this.type.toLowerCase() === "bm" )
@@ -964,14 +1112,19 @@ export class AlphaStrikeUnit {
                 numberOfHits = 5;
             }
 
-            for( let mpHitsCount = 0; mpHitsCount < numberOfHits; mpHitsCount++)
+            for( let mpHitsCount = 0; mpHitsCount < numberOfHits; mpHitsCount++) {
                 this.mpControlHits.push( false );
+                this.roundMpControlHits.push( false );
+            }
         }
 
         if( typeof( this.weaponHits ) === "undefined"  || this.weaponHits.length === 0  ) {
             this.weaponHits = [];
-            for( let weaponHitsCount = 0; weaponHitsCount < 4; weaponHitsCount++)
+            this.roundWeaponHits = [];
+            for( let weaponHitsCount = 0; weaponHitsCount < 4; weaponHitsCount++) {
                 this.weaponHits.push( false );
+                this.roundWeaponHits.push( false );
+            }
         }
 
 
@@ -1424,35 +1577,88 @@ export class AlphaStrikeUnit {
     }
 
     public setHeat( newHeatValue: number ) {
-        this.currentHeat = newHeatValue;
-        this.calcCurrentValues();
+        this.roundHeat = newHeatValue;
+    }
+
+    public applyRound() {
+        this.currentHeat = this.roundHeat;
+        this.roundArmor.map( (point, pointIndex) => {
+            if (point) {
+                this.currentArmor[pointIndex] = !this.currentArmor[pointIndex];
+                this.roundArmor[pointIndex] = false;
+            }
+        })
+        this.roundStructure.map( (point, pointIndex) => {
+            if (point) {
+                this.currentStructure[pointIndex] = !this.currentStructure[pointIndex];
+                this.roundStructure[pointIndex] = false;
+            }
+        })
+        this.roundEngineHits.map( (point, pointIndex) => {
+            if (point) {
+                this.engineHits[pointIndex] = !this.engineHits[pointIndex];
+                this.roundEngineHits[pointIndex] = false;
+            }
+        })
+        this.roundFireControlHits.map( (point, pointIndex) => {
+            if (point) {
+                this.fireControlHits[pointIndex] = !this.fireControlHits[pointIndex];
+                this.roundFireControlHits[pointIndex] = false;
+            }
+        })
+        this.roundMpControlHits.map( (point, pointIndex) => {
+            if (point) {
+                this.mpControlHits[pointIndex] = !this.mpControlHits[pointIndex];
+                this.roundMpControlHits[pointIndex] = false;
+            }
+        })
+        this.roundWeaponHits.map( (point, pointIndex) => {
+            if (point) {
+                this.weaponHits[pointIndex] = !this.weaponHits[pointIndex];
+                this.roundWeaponHits[pointIndex] = false;
+            }
+        })
+        this.roundVehicleMotive910.map( (point, pointIndex) => {
+            if (point) {
+                this.vehicleMotive910[pointIndex] = !this.vehicleMotive910[pointIndex];
+                this.roundVehicleMotive910[pointIndex] = false;
+            }
+        })
+        this.roundVehicleMotive11.map( (point, pointIndex) => {
+            if (point) {
+                this.vehicleMotive11[pointIndex] = !this.vehicleMotive11[pointIndex];
+                this.roundVehicleMotive11[pointIndex] = false;
+            }
+        })
+        if (this.roundVehicleMotive12) {
+            this.vehicleMotive12 = !this.vehicleMotive12;
+        }
+        this.roundVehicleMotive12 = false;
     }
 
     public takeDamage( numberOfPoints: number ) {
         let leftOverPoints = numberOfPoints;
 
         for( let pointCounter = 0; pointCounter < numberOfPoints; pointCounter++ ) {
-            for( let armorCounter = 0; armorCounter < this.currentArmor.length; armorCounter++ ) {
-                if( this.currentArmor[armorCounter] === false ) {
+            for( let armorCounter = 0; armorCounter < this.roundArmor.length; armorCounter++ ) {
+                if( this.roundArmor[armorCounter] === false && this.currentArmor[armorCounter] === false ) {
                     if( leftOverPoints > 0 ) {
-                        this.currentArmor[armorCounter] = true;
+                        this.roundArmor[armorCounter] = true;
                         leftOverPoints--;
                     }
-
+                } else if ( this.roundArmor[armorCounter] === true && this.currentArmor[armorCounter] === true ) {
+                    this.roundArmor[armorCounter] = false;
                 }
             }
 
-            for( let structureCounter = 0; structureCounter < this.currentStructure.length; structureCounter++ ) {
-                if( this.currentStructure[structureCounter] === false ) {
+            for( let structureCounter = 0; structureCounter < this.roundStructure.length; structureCounter++ ) {
+                if( this.roundStructure[structureCounter] === false && this.currentStructure[structureCounter] === false ) {
                     if( leftOverPoints > 0 ) {
-                        this.currentStructure[structureCounter] = true;
+                        this.roundStructure[structureCounter] = true;
                         leftOverPoints--;
-
-                        if( this.getCurrentStructure() === 0 )
-                            this.active = false;
-                        else
-                            this.active = true;
-                    }
+                    } 
+                } else if ( this.roundStructure[structureCounter] === true && this.currentStructure[structureCounter] === true ) {
+                    this.roundStructure[structureCounter] = false;
                 }
             }
         }
@@ -1488,12 +1694,9 @@ export class AlphaStrikeUnit {
 
     public setArmor( nv: number ) {
         this.armor = nv;
-
     }
     public setStructure( nv: number ) {
         this.armor = nv;
-
-
     }
 
     public export(
@@ -1514,6 +1717,16 @@ export class AlphaStrikeUnit {
 
         let _currentHeat = 0;
 
+        let _roundArmor: boolean[] = [];
+        let _roundStructure: boolean[] = [];
+        let _roundEngineHits: boolean[] = [];
+        let _roundFireControlHits: boolean[] = [];
+        let _roundMpControlHits: boolean[] = [];
+        let _roundWeaponHits: boolean[] = [];
+        let _roundVehicleMotive910: boolean[] = [];
+        let _roundVehicleMotive11: boolean[] = [];
+        let _roundVehicleMotive12: boolean = false;
+        let _roundHeat = 0;
 
         if( !noInPlayVariables ) {
             _currentArmor = this.currentArmor;
@@ -1527,6 +1740,16 @@ export class AlphaStrikeUnit {
             _vehicleMotive910 = this.vehicleMotive910;
             _vehicleMotive11 = this.vehicleMotive11;
             _vehicleMotive12 = this.vehicleMotive12;
+            _roundArmor = this.roundArmor;
+            _roundStructure = this.roundStructure;
+            _roundEngineHits = this.roundEngineHits;
+            _roundFireControlHits = this.roundFireControlHits;
+            _roundMpControlHits = this.roundMpControlHits;
+            _roundWeaponHits = this.roundWeaponHits;
+            _roundVehicleMotive910 = this.roundVehicleMotive910;
+            _roundVehicleMotive11 = this.roundVehicleMotive11;
+            _roundVehicleMotive12 = this.roundVehicleMotive12;
+            _roundHeat = this.roundHeat;
         }
 
         let rv:  IAlphaStrikeUnitExport = {
@@ -1541,6 +1764,16 @@ export class AlphaStrikeUnit {
             vehicleMotive910:  _vehicleMotive910,
             vehicleMotive11:  _vehicleMotive11,
             vehicleMotive12:  _vehicleMotive12,
+            roundArmor: _roundArmor,
+            roundStructure: _roundStructure,
+            roundEngineHits: _roundEngineHits,
+            roundFireControlHits: _roundFireControlHits,
+            roundMpControlHits: _roundMpControlHits,
+            roundWeaponHits: _roundWeaponHits,
+            roundVehicleMotive910: _roundVehicleMotive910,
+            roundVehicleMotive11: _roundVehicleMotive11,
+            roundVehicleMotive12: _roundVehicleMotive12,
+            roundHeat: _roundHeat,
             classification:  this.classification,
             class:  this.class?? "",
             costCR:  this.costCR,

--- a/src/classes/alpha-strike-unit.ts
+++ b/src/classes/alpha-strike-unit.ts
@@ -1039,36 +1039,57 @@ export class AlphaStrikeUnit {
 
         if( typeof( this.currentArmor ) === "undefined" || this.currentArmor.length === 0 ) {
             this.currentArmor = [];
-            this.roundArmor = [];
             for( let armorCount = 0; armorCount < this.armor; armorCount++) {
                 this.currentArmor.push( false );
+            }
+        }
+
+        if( typeof( this.roundArmor ) === "undefined" || this.roundArmor.length !== this.currentArmor.length ) {
+            this.roundArmor = [];
+            for( let armorCount = 0; armorCount < this.armor; armorCount++) {
                 this.roundArmor.push( false );
             }
         }
 
         if( typeof( this.currentStructure ) === "undefined" || this.currentStructure.length === 0 ) {
             this.currentStructure = [];
-            this.roundStructure = [];
             for( let structureCount = 0; structureCount < this.structure; structureCount++) {
                 this.currentStructure.push( false );
+            }
+        }
+
+        if( typeof( this.roundStructure ) === "undefined" || this.roundArmor.length !== this.currentStructure.length ) {
+            this.roundStructure = [];
+            for( let structureCount = 0; structureCount < this.armor; structureCount++) {
                 this.roundStructure.push( false );
             }
         }
 
         if( typeof( this.engineHits ) === "undefined"  || this.engineHits.length === 0  ) {
             this.engineHits = [];
-            this.roundEngineHits = [];
             for( let engineHitsCount = 0; engineHitsCount < 2; engineHitsCount++) {
                 this.engineHits.push( false );
                 this.roundEngineHits.push( false );
             }
         }
 
+        if( typeof( this.roundEngineHits ) === "undefined"  || this.roundEngineHits. length !== this.engineHits.length ) {
+            this.roundEngineHits = [];
+            for( let engineHitsCount = 0; engineHitsCount < 2; engineHitsCount++) {
+                this.roundEngineHits.push( false );
+            }
+        }
+
         if( typeof( this.fireControlHits ) === "undefined"  || this.fireControlHits.length === 0  ) {
             this.fireControlHits = [];
-            this.roundFireControlHits = [];
             for( let fcHitsCount = 0; fcHitsCount < 4; fcHitsCount++) {
                 this.fireControlHits.push( false );
+            }
+        }
+
+        if( typeof( this.roundFireControlHits ) === "undefined"  || this.roundFireControlHits.length !== this.fireControlHits.length  ) {
+            this.roundFireControlHits = [];
+            for( let fcHitsCount = 0; fcHitsCount < 4; fcHitsCount++) {
                 this.roundFireControlHits.push( false );
             }
         }
@@ -1081,6 +1102,14 @@ export class AlphaStrikeUnit {
                 this.roundVehicleMotive910.push( false );
             }
         }
+
+        if( typeof(this.roundVehicleMotive910) === "undefined" || this.roundVehicleMotive910.length !== this.vehicleMotive910.length ) {
+            this.roundVehicleMotive910 = [];
+            for(let hitCount = 0; hitCount < 2; hitCount++) {
+                this.roundVehicleMotive910.push( false );
+            }
+        }
+
         if( typeof(this.vehicleMotive11) === "undefined" || this.vehicleMotive11.length === 0 ) {
             this.vehicleMotive11 = [];
             this.roundVehicleMotive11 = [];
@@ -1090,9 +1119,15 @@ export class AlphaStrikeUnit {
             }
         }
 
+        if( typeof(this.roundVehicleMotive11) === "undefined" || this.roundVehicleMotive11.length !== this.vehicleMotive11.length ) {
+            this.roundVehicleMotive11 = [];
+            for(let hitCount = 0; hitCount < 2; hitCount++) {
+                this.roundVehicleMotive11.push( false );
+            }
+        }
+
         if( typeof( this.mpControlHits ) === "undefined"  || this.mpControlHits.length === 0  ) {
             this.mpControlHits = [];
-            this.roundMpControlHits = [];
             let numberOfHits = 4;
             if(
                 ( this.type && this.type.toLowerCase() === "bm" )
@@ -1114,6 +1149,11 @@ export class AlphaStrikeUnit {
 
             for( let mpHitsCount = 0; mpHitsCount < numberOfHits; mpHitsCount++) {
                 this.mpControlHits.push( false );
+            }
+        }
+
+        if( typeof( this.roundMpControlHits ) === "undefined"  || this.roundMpControlHits.length !== this.mpControlHits.length  ) {
+            for ( let mpHitsCount = 0; mpHitsCount < this.mpControlHits.length; mpHitsCount++) {
                 this.roundMpControlHits.push( false );
             }
         }
@@ -1127,7 +1167,12 @@ export class AlphaStrikeUnit {
             }
         }
 
-
+        if( typeof( this.roundWeaponHits ) === "undefined"  || this.roundWeaponHits.length !== this.weaponHits.length ) {
+            this.roundWeaponHits = [];
+            for( let weaponHitsCount = 0; weaponHitsCount < 4; weaponHitsCount++) {
+                this.roundWeaponHits.push( false );
+            }
+        }
 
 
 

--- a/src/ui/components/svg/alpha-strike-unit-svg.tsx
+++ b/src/ui/components/svg/alpha-strike-unit-svg.tsx
@@ -12,6 +12,9 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     buttonRadius = 15;
 
     activeDotColor = "rgb(200,0,0)";
+    roundDotColor = "rgb(0,180,180)";
+    roundStrokeColor = "rgb(0,140,140)";
+    roundActiveColor = "rgb(230,255,255)";
 
     critLineHeight = 50;
 
@@ -44,7 +47,6 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _takeDamage = ( damageTaken: number ): void => {
         if( this.props.inPlay && this.props.asUnit ) {
             this.props.asUnit.takeDamage( damageTaken );
-            this.props.asUnit.calcCurrentValues();
             this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
         }
         this.setState({
@@ -53,32 +55,25 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     }
 
     private _toggleArmorOrStructure = ( target: string, indexNumber: number ) => {
-
-
         if( this.props.inPlay && this.props.asUnit ) {
             if( target === "armor" ) {
-                if( this.props.asUnit.currentArmor.length > indexNumber) {
-                    this.props.asUnit.currentArmor[indexNumber] = !this.props.asUnit.currentArmor[indexNumber];
-                    this.props.asUnit.calcCurrentValues();
-                    this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
+                if( this.props.asUnit.roundArmor.length > indexNumber) {
+                    this.props.asUnit.roundArmor[indexNumber] = !this.props.asUnit.roundArmor[indexNumber];
                 }
 
             } else {
-                if( this.props.asUnit.currentStructure.length > indexNumber) {
-                    this.props.asUnit.currentStructure[indexNumber] = !this.props.asUnit.currentStructure[indexNumber];
-                    this.props.asUnit.calcCurrentValues();
-                    this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
+                if( this.props.asUnit.roundStructure.length > indexNumber) {
+                    this.props.asUnit.roundStructure[indexNumber] = !this.props.asUnit.roundStructure[indexNumber];
                 }
             }
+            this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
         }
     }
 
     private _toggleEngineHit = (  indexNumber: number ) => {
         if( this.props.inPlay && this.props.asUnit ) {
-
-            if( this.props.asUnit.engineHits.length > indexNumber) {
-                this.props.asUnit.engineHits[indexNumber] = !this.props.asUnit.engineHits[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundEngineHits.length > indexNumber) {
+                this.props.asUnit.roundEngineHits[indexNumber] = !this.props.asUnit.roundEngineHits[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
         }
@@ -86,8 +81,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
 
     private _setHeat = ( newValue: number ) => {
         if( this.props.inPlay && this.props.asUnit ) {
-            this.props.asUnit.currentHeat = newValue;
-            this.props.asUnit.calcCurrentValues();
+            this.props.asUnit.setHeat(newValue);
             this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
         }
     }
@@ -95,9 +89,8 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleWeaponHit = (indexNumber: number ): void =>  {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            if( this.props.asUnit.weaponHits.length > indexNumber) {
-                this.props.asUnit.weaponHits[indexNumber] = !this.props.asUnit.weaponHits[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundWeaponHits.length > indexNumber) {
+                this.props.asUnit.roundWeaponHits[indexNumber] = !this.props.asUnit.roundWeaponHits[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
         }
@@ -106,9 +99,8 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleVehicle910 = (indexNumber: number ): void =>  {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            if( this.props.asUnit.vehicleMotive910.length > indexNumber) {
-                this.props.asUnit.vehicleMotive910[indexNumber] = !this.props.asUnit.vehicleMotive910[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundVehicleMotive910.length > indexNumber) {
+                this.props.asUnit.roundVehicleMotive910[indexNumber] = !this.props.asUnit.roundVehicleMotive910[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
         }
@@ -117,9 +109,8 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleVehicle11 = (indexNumber: number ): void =>  {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            if( this.props.asUnit.vehicleMotive11.length > indexNumber) {
-                this.props.asUnit.vehicleMotive11[indexNumber] = !this.props.asUnit.vehicleMotive11[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundVehicleMotive11.length > indexNumber) {
+                this.props.asUnit.roundVehicleMotive11[indexNumber] = !this.props.asUnit.roundVehicleMotive11[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
         }
@@ -128,8 +119,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleVehicle12 = (): void => {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            this.props.asUnit.vehicleMotive12 = !this.props.asUnit.vehicleMotive12;
-            this.props.asUnit.calcCurrentValues();
+            this.props.asUnit.roundVehicleMotive12 = !this.props.asUnit.roundVehicleMotive12;
             this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
 
         }
@@ -138,9 +128,8 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleFireControlHit = (indexNumber: number ): void => {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            if( this.props.asUnit.fireControlHits.length > indexNumber) {
-                this.props.asUnit.fireControlHits[indexNumber] = !this.props.asUnit.fireControlHits[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundFireControlHits.length > indexNumber) {
+                this.props.asUnit.roundFireControlHits[indexNumber] = !this.props.asUnit.roundFireControlHits[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
         }
@@ -149,11 +138,17 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     private _toggleMPHit = (indexNumber: number ): void => {
         if( this.props.inPlay && this.props.asUnit ) {
 
-            if( this.props.asUnit.mpControlHits.length > indexNumber) {
-                this.props.asUnit.mpControlHits[indexNumber] = !this.props.asUnit.mpControlHits[indexNumber];
-                this.props.asUnit.calcCurrentValues();
+            if( this.props.asUnit.roundMpControlHits.length > indexNumber) {
+                this.props.asUnit.roundMpControlHits[indexNumber] = !this.props.asUnit.roundMpControlHits[indexNumber];
                 this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
             }
+        }
+    }
+
+    private _ApplyRound = (): void => {
+        if( this.props.inPlay && this.props.asUnit ) {
+            this.props.asUnit.applyRound();
+            this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
         }
     }
 
@@ -169,7 +164,6 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
     }
 
     private _makeArmorDots = (
-        count: number,
         xLoc: number,
         yLoc: number,
         fillColor: string = "rgb(255,255,255)",
@@ -182,52 +176,51 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
         if( radius === 0 ) {
             radius = this.buttonRadius - 5;
         }
-        let currentLeftCount = 0;
-        for( let currentCount = 0; currentCount < count; currentCount++ ) {
 
-            if( currentCount > 15 ) {
-
-                if( currentCount === 16) {
-                    yLoc += (radius * 2 + 9);
-                    currentLeftCount = 0;
-                } else {
-                    currentLeftCount++;
-                }
+        let dotArray: boolean[] = [];
+        let roundDotArray: boolean[] = [];
+        if (this.props.asUnit) {
+            if (target === "armor") {
+                dotArray = this.props.asUnit.currentArmor;
+                roundDotArray = this.props.asUnit.roundArmor;
             } else {
-                currentLeftCount = currentCount;
+                dotArray = this.props.asUnit.currentStructure;
+                roundDotArray = this.props.asUnit.roundStructure;
             }
+        }
+
+        dotArray.map( (point, pointIndex) => {
+            fillColor = target === "armor" ? "rgb(255,255,255)" :"rgb(153,153,153)";
+            strokeColor = "rgb(0,0,0)";
+
+            if (this.props.inPlay) {
+                if (roundDotArray[pointIndex]) {
+                    fillColor = !point ? this.roundDotColor : this.roundActiveColor;
+                    strokeColor = this.roundStrokeColor;
+                } else {
+                    fillColor = point ? this.activeDotColor : fillColor;
+                }
+            }
+
             dots.push(
-                <React.Fragment
-                    key={currentCount}
-                >
+                <React.Fragment key={pointIndex}>
                     <circle className={this.props.inPlay ? "cursor-pointer" : ""}
-                        cx={this.damageLeftBase + xLoc + (currentLeftCount * (radius * 2 + 9)) }
+                        cx={this.damageLeftBase + xLoc + (pointIndex * (radius * 2 + 9)) }
                         cy={yLoc}
                         r={radius + 3}
                         fill={strokeColor}
-                        onClick={() => this._toggleArmorOrStructure( target, currentCount )}
+                        onClick={() => this._toggleArmorOrStructure( target, pointIndex )}
                     />
-                    {target === "armor" ? (
-                        <circle className={this.props.inPlay ? "cursor-pointer" : ""}
-                            cx={this.damageLeftBase + xLoc + (currentLeftCount * (radius * 2 + 9)) }
-                            cy={yLoc}
-                            r={radius}
-                            fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentArmor.length > currentCount && this.props.asUnit.currentArmor[currentCount] ? this.activeDotColor : fillColor}
-                            onClick={() => this._toggleArmorOrStructure( target, currentCount )}
-                        />
-                    ) : (
-                        <circle className={this.props.inPlay ? "cursor-pointer" : ""}
-                            cx={this.damageLeftBase + xLoc + (currentLeftCount * (radius * 2 + 9)) }
-                            cy={yLoc}
-                            r={radius}
-                            fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentStructure.length > currentCount && this.props.asUnit.currentStructure[currentCount] ? this.activeDotColor : fillColor}
-                            onClick={() => this._toggleArmorOrStructure( target, currentCount )}
-                        />
-                    )}
-
+                    <circle className={this.props.inPlay ? "cursor-pointer" : ""}
+                        cx={this.damageLeftBase + xLoc + (pointIndex * (radius * 2 + 9)) }
+                        cy={yLoc}
+                        r={radius}
+                        fill={fillColor}
+                        onClick={() => this._toggleArmorOrStructure( target, pointIndex )}
+                    />
                 </React.Fragment>
             )
-        }
+        })
 
         return dots;
     }
@@ -448,7 +441,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     y="330"
                     width="25"
                     height="50"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 0 ? "rgb(0,200,0)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 0 ? "rgb(0,200,0)" : this.props.inPlay && this.props.asUnit.roundHeat === 0 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></rect>
                 <circle
                     onClick={() => this._setHeat(0)}
@@ -456,7 +449,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     cx="325"
                     cy="355"
                     r="25"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 0 ? "rgb(0,200,0)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 0 ? "rgb(0,200,0)" : this.props.inPlay && this.props.asUnit.roundHeat === 0 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></circle>
                 <text onClick={() => this._setHeat(0)} className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""} x="315" y="368" textAnchor="left" style={{fill: "rgb(255,255,255)"}} fontFamily="sans-serif" fontSize={35}>0</text>
 
@@ -468,7 +461,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     y="330"
                     width="45"
                     height="50"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 1 ? "rgb(204, 187, 0)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 1 ? "rgb(204, 187, 0)" : this.props.inPlay && this.props.asUnit.roundHeat === 1 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></rect>
                 <text onClick={() => this._setHeat(1)} className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""} x="365" y="368" textAnchor="left" style={{fill: "rgb(255,255,255)"}} fontFamily="sans-serif" fontSize={35}>1</text>
 
@@ -480,7 +473,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     y="330"
                     width="45"
                     height="50"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 2 ? "rgb(236,87,16)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 2 ? "rgb(236,87,16)" : this.props.inPlay && this.props.asUnit.roundHeat === 2 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></rect>
                 <text onClick={() => this._setHeat(2)} className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""} x="415" y="368" textAnchor="left" style={{fill: "rgb(255,255,255)"}} fontFamily="sans-serif" fontSize={35}>2</text>
 
@@ -492,7 +485,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     y="330"
                     width="45"
                     height="50"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 3 ? "rgb(200,0,0)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat === 3 ? "rgb(200,0,0)" : this.props.inPlay && this.props.asUnit.roundHeat === 3 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></rect>
                 <text onClick={() => this._setHeat(3)} className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""} x="465" y="368" textAnchor="left" style={{fill: "rgb(255,255,255)"}} fontFamily="sans-serif" fontSize={35}>3</text>
 
@@ -504,7 +497,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     y="330"
                     width="25"
                     height="50"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat > 3 ? "rgb(255,10,10)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat > 3 ? "rgb(255,10,10)" : this.props.inPlay && this.props.asUnit.roundHeat > 3 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></rect>
                 <circle
                     onClick={() => this._setHeat(4)}
@@ -512,7 +505,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     cx="530"
                     cy="355"
                     r="25"
-                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat > 3 ? "rgb(255,10,10)" : "rgb(102,102,102)"}
+                    fill={this.props.inPlay && this.props.asUnit && this.props.asUnit.currentHeat > 3 ? "rgb(255,10,10)" : this.props.asUnit.roundHeat > 3 ? this.roundDotColor : "rgb(102,102,102)"}
                 ></circle>
                 <text onClick={() => this._setHeat(4)} className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""} x="515" y="368" textAnchor="left" style={{fill: "rgb(255,255,255)"}} fontFamily="sans-serif" fontSize={35}>S</text>
 
@@ -574,7 +567,6 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     <text x={this.damageLeftBase + 40} y="440" fontFamily="sans-serif" fontSize="25">A: </text>
 
                     {this._makeArmorDots(
-                        this.props.asUnit.armor,
                         90,
                         this.props.asUnit.armor > 16 ? 420 : 432,
                         "rgb(255,255,255)",
@@ -587,7 +579,6 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     {/* Structure */}
                     <text x={this.damageLeftBase + 40} y="485" fontFamily="sans-serif" fontSize="25">S: </text>
                     {this._makeArmorDots(
-                        this.props.asUnit.structure,
                         90,
                         477,
                         "rgb(153,153,153)",
@@ -703,9 +694,10 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                         <text x="750" y={critLineStart} textAnchor="end" fontFamily="sans-serif" fontSize="20">ENGINE</text>
 
                         {this.props.asUnit.engineHits.map( (ehValue, ehIndex) => {
-                            let fillColor = "rgb(255,255,255)";
-                            if( ehValue ) {
-                                fillColor = this.activeDotColor;
+                            let fillColor = this.props.inPlay && this.props.asUnit?.roundEngineHits[ehIndex] ? this.roundDotColor : "rgb(255,255,255)";
+                            let strokeColor = this.props.inPlay && this.props.asUnit?.roundEngineHits[ehIndex] ? this.roundStrokeColor : "rgb(0,0,0)";
+                            if( this.props.inPlay && ehValue ) {
+                                fillColor = this.props.asUnit?.roundEngineHits[ehIndex] ? this.roundActiveColor : this.activeDotColor;
                             }
                             return (
                                 <React.Fragment key={ehIndex}>
@@ -713,7 +705,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                                         cx={770 + (this.buttonRadius * 2 + 3 ) * ehIndex}
                                         cy={critLineStart - 27 + this.buttonRadius + 2}
                                         r={this.buttonRadius}
-                                        fill="rgb(0,0,0)"
+                                        fill={strokeColor}
                                         className={this.props.inPlay ? "cursor-pointer" : ""}
                                         onClick={() => this._toggleEngineHit(ehIndex)}
                                     ></circle>
@@ -738,9 +730,10 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
 
                 <text x="750" y={critLineStart} textAnchor="end" fontFamily="sans-serif" fontSize="20">FIRE CONTROL</text>
                 {this.props.asUnit.fireControlHits.map( (fcValue, fcIndex) => {
-                            let fillColor = "rgb(255,255,255)";
-                            if( fcValue ) {
-                                fillColor = this.activeDotColor;
+                            let fillColor = this.props.inPlay && this.props.asUnit?.roundFireControlHits[fcIndex] ? this.roundDotColor : "rgb(255,255,255)";
+                            let strokeColor = this.props.inPlay && this.props.asUnit?.roundFireControlHits[fcIndex] ? this.roundStrokeColor : "rgb(0,0,0)";
+                            if( this.props.inPlay &&  fcValue ) {
+                                fillColor = this.props.asUnit?.roundFireControlHits[fcIndex] ? this.roundActiveColor : this.activeDotColor;
                             }
                             return (
                                 <React.Fragment key={fcIndex}>
@@ -748,7 +741,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                                         cx={770 + (this.buttonRadius * 2 + 3 ) * fcIndex}
                                         cy={critLineStart - 27 + this.buttonRadius + 2}
                                         r={this.buttonRadius}
-                                        fill="rgb(0,0,0)"
+                                        fill={strokeColor}
                                         className={this.props.inPlay ? "cursor-pointer" : ""}
                                         onClick={() => this._toggleFireControlHit(fcIndex)}
                                     ></circle>
@@ -770,9 +763,10 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                     <>
                         <text x="750"y={critLineStart} textAnchor="end" fontFamily="sans-serif" fontSize="20">MP</text>
                         {this.props.asUnit.mpControlHits.map( (mpValue, mpIndex) => {
-                            let fillColor = "rgb(255,255,255)";
-                            if( mpValue ) {
-                                fillColor = this.activeDotColor;
+                            let fillColor = this.props.inPlay && this.props.asUnit?.roundMpControlHits[mpIndex] ? this.roundDotColor : "rgb(255,255,255)";
+                            let strokeColor = this.props.inPlay && this.props.asUnit?.roundMpControlHits[mpIndex] ? this.roundStrokeColor : "rgb(0,0,0)";
+                            if( this.props.inPlay &&  mpValue ) {
+                                fillColor = this.props.asUnit?.roundMpControlHits[mpIndex] ? this.roundActiveColor : this.activeDotColor;
                             }
                             return (
                                 <React.Fragment key={mpIndex}>
@@ -780,7 +774,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                                         cx={770 + (this.buttonRadius * 2 + 3 ) * mpIndex}
                                         cy={critLineStart - 27 + this.buttonRadius + 2}
                                         r={this.buttonRadius}
-                                        fill="rgb(0,0,0)"
+                                        fill={strokeColor}
                                         className={this.props.inPlay ? "cursor-pointer" : ""}
                                         onClick={() => this._toggleMPHit(mpIndex)}
                                     ></circle>
@@ -805,9 +799,10 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
 
                 <text x="750" y={critLineStart} textAnchor="end" fontFamily="sans-serif" fontSize="20">WEAPONS</text>
                 {this.props.asUnit.weaponHits.map( (whValue, whIndex) => {
-                            let fillColor = "rgb(255,255,255)";
-                            if( whValue ) {
-                                fillColor = this.activeDotColor;
+                            let fillColor = this.props.inPlay && this.props.asUnit?.roundWeaponHits[whIndex] ? this.roundDotColor : "rgb(255,255,255)";
+                            let strokeColor = this.props.inPlay && this.props.asUnit?.roundWeaponHits[whIndex] ? this.roundStrokeColor : "rgb(0,0,0)";
+                            if( whValue && this.props.inPlay ) {
+                                fillColor = this.props.inPlay && this.props.asUnit?.roundWeaponHits[whIndex] ? this.roundActiveColor : this.activeDotColor;
                             }
                             return (
                                 <React.Fragment key={whIndex}>
@@ -815,7 +810,7 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                                         cx={770 + (this.buttonRadius * 2 + 3 ) * whIndex}
                                         cy={critLineStart - 27 + this.buttonRadius + 2}
                                         r={this.buttonRadius}
-                                        fill="rgb(0,0,0)"
+                                        fill={strokeColor}
                                         className={this.props.inPlay ? "cursor-pointer" : ""}
                                         onClick={() => this._toggleWeaponHit(whIndex)}
                                     ></circle>
@@ -836,16 +831,19 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
                 {this.props.asUnit.type.toLowerCase() === 'cv' ||  this.props.asUnit.type.toLowerCase() === 'sv'? (
                     <>
                         <text x="750" y={critLineStart} textAnchor="end" fontFamily="sans-serif" fontSize="20">MOTIVE</text>
-                        <circle onClick={() => this._toggleVehicle910(0)} className="" cx="770" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill="rgb(0,0,0)"></circle>
-                        <circle onClick={() => this._toggleVehicle910(0)} className="" cx="770" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.asUnit.vehicleMotive910[0] ? this.activeDotColor : "rgb(255,255,255)"}></circle>
-                        <circle onClick={() => this._toggleVehicle910(1)} className="" cx="801" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill="rgb(0,0,0)"></circle>
-                        <circle onClick={() => this._toggleVehicle910(1)} className="" cx="801" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.asUnit.vehicleMotive910[1] ? this.activeDotColor : "rgb(255,255,255)"}></circle>
-                        <circle onClick={() => this._toggleVehicle11(0)} className="" cx="847" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill="rgb(0,0,0)"></circle>
-                        <circle onClick={() => this._toggleVehicle11(0)} className="" cx="847" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.asUnit.vehicleMotive11[0] ? this.activeDotColor : "rgb(255,255,255)"}></circle>
-                        <circle onClick={() => this._toggleVehicle11(1)} className="" cx="878" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill="rgb(0,0,0)"></circle>
-                        <circle onClick={() => this._toggleVehicle11(1)} className="" cx="878" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.asUnit.vehicleMotive11[1] ? this.activeDotColor : "rgb(255,255,255)"}></circle>
-                        <circle onClick={() => this._toggleVehicle12()} className="" cx="934" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill="rgb(0,0,0)"></circle>
-                        <circle onClick={() => this._toggleVehicle12()} className="" cx="934" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.asUnit.vehicleMotive12 ? this.activeDotColor : "rgb(255,255,255)"}></circle>
+                        
+                        <circle onClick={() => this._toggleVehicle910(0)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="770" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill={this.props.inPlay && this.props.asUnit.roundVehicleMotive910[0] ? this.roundStrokeColor : "rgb(0,0,0)"}></circle>
+                        <circle onClick={() => this._toggleVehicle910(0)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="770" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.inPlay && this.props.asUnit.vehicleMotive910[0] ? this.props.asUnit.roundVehicleMotive910[0] ? this.roundActiveColor : this.activeDotColor : this.props.inPlay && this.props.asUnit.roundVehicleMotive910[0] ? this.roundDotColor : "rgb(255,255,255)"}></circle>
+                        <circle onClick={() => this._toggleVehicle910(1)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="801" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill={this.props.inPlay && this.props.asUnit.roundVehicleMotive910[1] ? this.roundStrokeColor : "rgb(0,0,0)"}></circle>
+                        <circle onClick={() => this._toggleVehicle910(1)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="801" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.inPlay && this.props.asUnit.vehicleMotive910[1] ? this.props.asUnit.roundVehicleMotive910[1] ? this.roundActiveColor : this.activeDotColor : this.props.inPlay && this.props.asUnit.roundVehicleMotive910[1] ? this.roundDotColor : "rgb(255,255,255)"}></circle>
+                        
+                        <circle onClick={() => this._toggleVehicle11(0)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="847" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill={this.props.inPlay && this.props.asUnit.roundVehicleMotive11[0] ? this.roundStrokeColor : "rgb(0,0,0)"}></circle>
+                        <circle onClick={() => this._toggleVehicle11(0)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="847" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.inPlay && this.props.asUnit.vehicleMotive11[0] ? this.props.asUnit.roundVehicleMotive11[0] ? this.roundActiveColor : this.activeDotColor : this.props.inPlay && this.props.asUnit.roundVehicleMotive11[0] ? this.roundDotColor : "rgb(255,255,255)"}></circle>
+                        <circle onClick={() => this._toggleVehicle11(1)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="878" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill={this.props.inPlay && this.props.asUnit.roundVehicleMotive11[1] ? this.roundStrokeColor : "rgb(0,0,0)"}></circle>
+                        <circle onClick={() => this._toggleVehicle11(1)} className={this.props.inPlay ? "cursor-pointer" : ""} cx="878" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.inPlay && this.props.asUnit.vehicleMotive11[1] ? this.props.asUnit.roundVehicleMotive11[1] ? this.roundActiveColor : this.activeDotColor : this.props.inPlay && this.props.asUnit.roundVehicleMotive11[1] ? this.roundDotColor : "rgb(255,255,255)"}></circle>
+                        
+                        <circle onClick={() => this._toggleVehicle12()} className={this.props.inPlay ? "cursor-pointer" : ""} cx="934" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius} fill={this.props.inPlay && this.props.asUnit.roundVehicleMotive12 ? this.roundStrokeColor : "rgb(0,0,0)"}></circle>
+                        <circle onClick={() => this._toggleVehicle12()} className={this.props.inPlay ? "cursor-pointer" : ""} cx="934" cy={critLineStart + this.buttonRadius - 27 + 3} r={this.buttonRadius - 3} fill={this.props.inPlay && this.props.asUnit.vehicleMotive12 ? this.props.asUnit.roundVehicleMotive12 ? this.roundActiveColor : this.activeDotColor : this.props.inPlay && this.props.asUnit.roundVehicleMotive12 ? this.roundDotColor : "rgb(255,255,255)"}></circle>
                         <text x="775" y={critLineStart + this.buttonRadius + 3} textAnchor="start" fontFamily="sans-serif" fontSize="8">-2 MV</text>
                         <text x="827" y={critLineStart + this.buttonRadius + 3} textAnchor="start" fontFamily="sans-serif" fontSize="8">½ Move &amp; TMM Each</text>
                         <text x="919" y={critLineStart + this.buttonRadius + 3} textAnchor="start" fontFamily="sans-serif" fontSize="8">0 MV</text>
@@ -874,6 +872,21 @@ export default class AlphaStrikeUnitSVG extends React.Component<IAlphaStrikeUnit
 
                 <rect x="10" y="610" width="960" height="35" fill="rgb(0,0,0)"></rect>
                 <text x="20" y="625" textAnchor="start" fontFamily="sans-serif" fill="rgb(253,253,227)" style={{fontWeight: 700}} fontSize="30">ALPHA STRIKE</text>
+
+                {this.props.inPlay && this.props.asUnit.hasRoundStaged() ? (
+                    <g transform='translate(435, 584)'>
+                        <rect x="0" y="0" width="130" height="40" rx="5" ry="5" onClick={(e) => this._ApplyRound()} fill={this.roundDotColor} stroke={this.roundStrokeColor} strokeWidth={3}></rect>
+                        <text x="65" y="30" 
+                            onClick={(e) => this._ApplyRound()}
+                            className={this.props.inPlay && this.props.asUnit ? "cursor-pointer" : ""}
+                            fontFamily="sans-serif" 
+                            fontSize="30"
+                            fontWeight="bold"
+                            fill="rgb(255,255,255)"
+                            textAnchor='middle'
+                            >APPLY</text>
+                    </g>
+                ) : null }
 
                 <BattleTechLogo
                     xLoc={750}

--- a/src/ui/pages/alpha-strike/roster/in-play.tsx
+++ b/src/ui/pages/alpha-strike/roster/in-play.tsx
@@ -33,16 +33,26 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
     ): void => {
       if( e && e.preventDefault ) e.preventDefault();
 
-      if (this.props.appGlobals.currentASForce) {
-        for (let group of this.props.appGlobals.currentASForce.groups) {
-          for( let unit of group.members ) {
-            unit.applyRound();
-          }
+      this.props.appGlobals.openConfirmDialog(
+        "End Round",
+        "Ending the round will apply all the pending updates to all units heat and damage.",
+        "End Round",
+        "Cancel",
+        () => {
+          if (this.props.appGlobals.currentASForce) {
+            for (let group of this.props.appGlobals.currentASForce.groups) {
+              for( let unit of group.members ) {
+                unit.applyRound();
+              }
+            }
+    
+            this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
+    
+          }  
         }
+      )
 
-        this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
-
-      }      
+          
     } 
 
     toggleCardMode = (

--- a/src/ui/pages/alpha-strike/roster/in-play.tsx
+++ b/src/ui/pages/alpha-strike/roster/in-play.tsx
@@ -28,8 +28,22 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
         this.props.appGlobals.makeDocumentTitle("Playing Alpha Strike");
     }
 
+    nextRound = (
+      e: React.FormEvent<HTMLSpanElement>
+    ): void => {
+      if( e && e.preventDefault ) e.preventDefault();
 
+      if (this.props.appGlobals.currentASForce) {
+        for (let group of this.props.appGlobals.currentASForce.groups) {
+          for( let unit of group.members ) {
+            unit.applyRound();
+          }
+        }
 
+        this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );
+
+      }      
+    } 
 
     toggleCardMode = (
       e: React.FormEvent<HTMLSpanElement>
@@ -161,6 +175,8 @@ export default class AlphaStrikeRosterInPlay extends React.Component<IInPlayProp
                     appGlobals={this.props.appGlobals}
                   />
                 </li>
+
+                <li title="Apply damage and heat changes to end the round"><span className="" onClick={this.nextRound}>End Round</span></li>
 
                 <li className="logo">
                     <a


### PR DESCRIPTION
Dots and heat will now indicate the future state in teal. When a unit has round changes staged, it will show an "Apply" button to commit the changes immediately.

There is also now a "End Round" button in the main menu that will apply all the changes for all the units. Unit stats are not updated until the changes are committed.

The "Reset" button for each group will revert both current and round damage and heat.

![image](https://github.com/user-attachments/assets/6a7bc50d-0b42-4102-a512-c70ed778b9fd)
