### PR TITLE
Print mode improvements

### DIFF
--- a/src/ui/pages/alpha-strike/roster/print.scss
+++ b/src/ui/pages/alpha-strike/roster/print.scss
@@ -47,12 +47,16 @@ header {
         .section-content {
             display: flex;
             flex-wrap: wrap;
+            padding: 0 !important;
+            &:not(.tokens) {
+                gap: 10%;
+            }
             .lance-bonus {
                 font-size: 14px;
             }
             .unit-card,
             .ability-card {
-                flex-basis: 50%;
+                flex-basis: 45%;
                 padding: 5px;
             }
             .ability-card {


### PR DESCRIPTION
Formation bonus descriptions moved to the same page(s) as SPA cards to allow for more units per page.

The print mode will now optimize for fitting up to 8 units per page and up to 4 lances.