### PR TITLE
Add infantry formations

### DIFF
--- a/src/classes/alpha-strike-force.ts
+++ b/src/classes/alpha-strike-force.ts
@@ -82,7 +82,14 @@ export default class AlphaStrikeForce {
                 // let newUnit = new AlphaStrikeUnit( exportData );
                 this.groups[groupIndex].members.push( mulUnit  );
                 this.groups[groupIndex].sortUnits();
-                this.groups[groupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[groupIndex])));
+                this.groups[groupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[groupIndex], this.groups)));
+
+                // Used to update nova/mechanized check
+                for(let group of this.groups){
+                    if(group.needsToCheckBonuses()){
+                        group.setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(group, this.groups)));
+                    }
+                }
             // }
         }
 
@@ -106,8 +113,13 @@ export default class AlphaStrikeForce {
 
                 this.groups[toGroupIndex].sortUnits();
                 this.groups[fromGroupIndex].sortUnits();
-                this.groups[toGroupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[toGroupIndex])));
-                this.groups[fromGroupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[fromGroupIndex])));
+                this.groups[toGroupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[toGroupIndex], this.groups)));
+                this.groups[fromGroupIndex].setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(this.groups[fromGroupIndex], this.groups)));
+                for(let group of this.groups){
+                    if(group.needsToCheckBonuses()){
+                        group.setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(group, this.groups)));
+                    }
+                }
             }
         }
     }
@@ -120,7 +132,12 @@ export default class AlphaStrikeForce {
         if( this.groups.length > asGroupIndex && this.groups[asGroupIndex]) {
             if( this.groups[asGroupIndex].members.length > asUnitIndex && this.groups[asGroupIndex].members[asUnitIndex]) {
                 this.groups[asGroupIndex].members.splice( asUnitIndex, 1);
-                this.groups[asGroupIndex].setAvailableFormationBonuses(formationBonuses.filter(x=>x.IsValid(this.groups[asGroupIndex])));
+                this.groups[asGroupIndex].setAvailableFormationBonuses(formationBonuses.filter(x=>x.IsValid(this.groups[asGroupIndex], this.groups)));
+                for(let group of this.groups){
+                    if(group.needsToCheckBonuses()){
+                        group.setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(group, this.groups)));
+                    }
+                }
             }
         }
     }

--- a/src/classes/alpha-strike-force.ts
+++ b/src/classes/alpha-strike-force.ts
@@ -31,6 +31,7 @@ export default class AlphaStrikeForce {
     constructor(importObj: IASForceExport | null = null ) {
         if( importObj ) {
             this.import(importObj);
+            this.validateAllGroups();
         }
 
         if( this.groups.length === 0 ) {
@@ -191,6 +192,23 @@ export default class AlphaStrikeForce {
         return returnValue;
     }
 
+    public validateAllGroups(): void {
+        // First validate each group individually
+        for (let group of this.groups) {
+            group.setAvailableFormationBonuses(formationBonuses.filter(x => x.IsValid(group, this.groups)));
+        }
+
+        // Then revalidate all groups to ensure cross-group dependencies are met
+        for (let group of this.groups) {
+            if (group.formationBonus) {
+                // If the current formation bonus is no longer valid, reset to None
+                if (!group.availableFormationBonuses.find(x => x.Name === group.formationBonus?.Name)) {
+                    group.formationBonus = formationBonuses.find(x => x.Name === "None");
+                }
+            }
+        }
+    }
+
     public import(importObj: IASForceExport) {
         for( let group of importObj.groups ) {
             this.groups.push( new AlphaStrikeGroup( group) );
@@ -206,6 +224,5 @@ export default class AlphaStrikeForce {
         if( importObj.lastUpdated ) {
             this._lastUpdated = new Date(importObj.lastUpdated);
         }
-
     }
 }

--- a/src/classes/alpha-strike-group.ts
+++ b/src/classes/alpha-strike-group.ts
@@ -37,7 +37,7 @@ export default class AlphaStrikeGroup {
 		}
 
 		this.sortUnits();
-		this.availableFormationBonuses= formationBonuses.filter(x=>x.IsValid(this));
+		this.availableFormationBonuses= formationBonuses.filter(x=>x.IsValid(this, []));
 	}
 
 	public getActiveMembers() {
@@ -65,6 +65,11 @@ export default class AlphaStrikeGroup {
 		}
 		return false;
 	}
+
+  // Currently used just for nova/mechanized check since it is dependent on other groups
+  public needsToCheckBonuses(): boolean {
+    return this.members.filter(x => x.isInfantry).length === this.members.length;
+  }
 
     public getTotalPoints(): number {
         let returnValue: number = 0;

--- a/src/classes/alpha-strike-group.ts
+++ b/src/classes/alpha-strike-group.ts
@@ -180,9 +180,11 @@ export default class AlphaStrikeGroup {
 
         if( importObj.lastUpdated ) {
             this.lastUpdated = new Date(importObj.lastUpdated);
-		}
-		if( importObj.formationBonus ){
-			this.formationBonus = formationBonuses.find(x=>x.Name===importObj.formationBonus);
-		}
+        }
+
+        // Store the formation bonus name but don't set it yet
+        if( importObj.formationBonus ){
+            this.formationBonus = formationBonuses.find(x=>x.Name===importObj.formationBonus);
+        }
     }
 }

--- a/src/ui/pages/alpha-strike/roster/_showAlphaStrikeUnit.tsx
+++ b/src/ui/pages/alpha-strike/roster/_showAlphaStrikeUnit.tsx
@@ -21,7 +21,16 @@ export default class AlphaStrikeUnitEditViewModal extends React.Component<IAlpha
       if(this.props.showASUnit) {
         this.props.showASUnit.setSkill( +event.currentTarget.value );
         for(let i = 0; i < this.props.appGlobals.currentASForce!.groups.length; i++){
-          this.props.appGlobals.currentASForce!.groups[i].setAvailableFormationBonuses(formationBonuses.filter(x => x.IsValid(this.props.appGlobals.currentASForce!.groups[i])));
+          this.props.appGlobals.currentASForce!.groups[
+            i
+          ].setAvailableFormationBonuses(
+            formationBonuses.filter((x) =>
+              x.IsValid(
+                this.props.appGlobals.currentASForce!.groups[i],
+                this.props.appGlobals.currentASForce!.groups
+              )
+            )
+          );
           console.log(this.props.appGlobals.currentASForce!.groups[i].availableFormationBonuses)
          }
         this.props.appGlobals.saveCurrentASForce( this.props.appGlobals.currentASForce );

--- a/src/ui/pages/alpha-strike/roster/home.tsx
+++ b/src/ui/pages/alpha-strike/roster/home.tsx
@@ -128,7 +128,12 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
         }
 
         if( newGroup.members.length > 0 ) {
-          newGroup.setAvailableFormationBonuses(formationBonuses.filter(x=>x.IsValid(newGroup)))
+          newGroup.setAvailableFormationBonuses(formationBonuses.filter(x=>x.IsValid(newGroup, currentASForce?.groups ?? [])))
+          for(let group of currentASForce?.groups ?? []){
+              if(group.needsToCheckBonuses()){
+                  group.setAvailableFormationBonuses( formationBonuses.filter(x=>x.IsValid(group, currentASForce?.groups ?? [])));
+              }
+          }
           currentASForce.groups.push( newGroup );
           this.props.appGlobals.saveCurrentASForce( currentASForce );
           this.setState({


### PR DESCRIPTION
Adding in mechanized and nova. Definitely open to feedback on how you'd prefer this be organized differently 👍 I tested it but there's a lot going on here and would highly value some extra eyes on testing it.
It is a little bit different than other formation bonuses since this one is built on top of an existing formation. What you have to do is create a formation of just infantry/battle armor, then a separate formation that can transport all of them. When other formations are modified, it will check if any of the others qualify as being able to transport all of them.