### PR TITLE
Added Force Pack Visibility Setting

### DIFF
--- a/src/ui/classes/app_settings.ts
+++ b/src/ui/classes/app_settings.ts
@@ -4,6 +4,7 @@ import { ESaveDataMode } from "../../dataSaves";
 export class AppSettings {
     developerMenu: boolean = false;
     alphaStrikeMeasurementsInHexes: boolean = false;
+    alphaStrikeForcePackVisibility: boolean = true;
     uiTheme: string = "";
     equipmentFilter: string = "";
     installEquipCategory: string = "";

--- a/src/ui/pages/alpha-strike/roster/home.tsx
+++ b/src/ui/pages/alpha-strike/roster/home.tsx
@@ -445,6 +445,7 @@ export default class AlphaStrikeRosterHome extends React.Component<IHomeProps, I
 </TextSection>
 ): null}
 
+{ this.props.appGlobals.appSettings.alphaStrikeForcePackVisibility ? ( 
 <TextSection
 label="Quickly add a ForcePack"
 >
@@ -470,7 +471,7 @@ label="Quickly add a ForcePack"
     We're sorry, adding a Force Pack needs access to the Master Unit List for unit stats and requires an Internet connection, please connect to the Internet.
   </div>
 )}
-</TextSection>
+</TextSection>) : null }
 
 <TextSection
 label='Import to your AS Favorites'

--- a/src/ui/pages/settings/home.tsx
+++ b/src/ui/pages/settings/home.tsx
@@ -43,6 +43,12 @@ export default class SettingsHome extends React.Component<ISettingsHomeProps, IS
       })
     }
 
+    setAlphaStrikeForcePackVisibility = ( event: React.FormEvent<HTMLInputElement>): void => {
+      let appSettingsHome = this.props.appGlobals.appSettings;
+      appSettingsHome.alphaStrikeForcePackVisibility = event.currentTarget.checked;
+      this.props.appGlobals.saveAppSettings( appSettingsHome );
+    }
+
     render = (): JSX.Element => {
 
       return (
@@ -74,6 +80,12 @@ export default class SettingsHome extends React.Component<ISettingsHomeProps, IS
                   label='Alpha Strike Roster: Display Measurements in Hexes'
                   checked={this.props.appGlobals.appSettings.alphaStrikeMeasurementsInHexes}
                   onChange={this.setAlphaStrikeMeasurementsInHexes}
+                />
+
+                <InputCheckbox
+                  label='Alpha Strike Roster: Show Force Packs'
+                  checked={this.props.appGlobals.appSettings.alphaStrikeForcePackVisibility}
+                  onChange={this.setAlphaStrikeForcePackVisibility}
                 />
 
                 </fieldset>


### PR DESCRIPTION
This provides a setting to hide the super long list of force packs from the Alpha Strike roster.